### PR TITLE
Make H2 database file-based

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ out/
 *.log
 logs/
 log/
+
+### Database ###
+*.db

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,10 +2,13 @@ spring.application.name=Expense Tracker
 
 # Database Configuration
 spring.h2.console.enabled=true
-spring.datasource.url=jdbc:h2:mem:expensetracker
+spring.datasource.url=jdbc:h2:file:./expenses.dbadd
 spring.datasource.driverClassName=org.h2.Driver
 spring.datasource.username=sa
 spring.datasource.password=password
+spring.jpa.hibernate.ddl-auto=update
+
+
 spring.shell.interactive.enabled=true
 
 


### PR DESCRIPTION
This pull request includes changes to the database configuration settings in the `application.properties` file. The most important changes focus on modifying the data source URL and enabling automatic schema updates.

Changes to database configuration:

* [`src/main/resources/application.properties`](diffhunk://#diff-54eeffbae371fcd1398d4ca5e89a1b8118208b7bb2f8ddf55c1aa2f7d98ab136L5-R11): Changed `spring.datasource.url` from an in-memory database to a file-based database (`jdbc:h2:file:./expenses.dbadd`).
* [`src/main/resources/application.properties`](diffhunk://#diff-54eeffbae371fcd1398d4ca5e89a1b8118208b7bb2f8ddf55c1aa2f7d98ab136L5-R11): Added `spring.jpa.hibernate.ddl-auto=update` to enable automatic schema updates.